### PR TITLE
add links to and cleanup Readme

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -1,159 +1,157 @@
 # Mac and Linux Scripts
-archetypeShower.sh #####   Purpose: bash script to show screenfetch 
-
-backupBashConfig.sh #####   Purpose: bash script to backup dotfiles
-
-batchRename.sh #####   Purpose: bash script to rename multiple files
-
-blueText.sh #####   Purpose: bash script for making text blue
-
-blueUpperText.sh #####   Purpose: bash script to make text white on blue background and some underscores
-
-boldText.sh #####   Purpose: bash script to bold text
-
-clearTrash.sh #####   Purpose: bash script to empty trash
-
-colorLogger.sh #####   Purpose: bash script to monitor log files in color
-
-connectionShower.sh #####   Purpose: bash script to continuously monitor open files
-
-coolFormatter.sh #####   Purpose: bash script to add funky formatting 
-
-createScriptButDontOpenSublime.sh #####   Purpose: bash script to add shebang line to new script file
-
-createTextFile.sh #####   Purpose: bash script to create new script and edit it with SublimeText 
-
-directoryContentsSize.sh #####   Purpose: bash script to list files and folders in pwd and optionally sort by size
-
-dsDownloader.sh #####   Purpose: bash  script to download from RPi to local host
-
-duplicateLineDeleter.sh #####   Purpose: bash script to remove lines with no contents (squeeze)
-
-eyes.sh #####   Purpose: bash script to show cowsay eyes
-
-genericDisplayer.sh #####   Purpose: bash script to display output with invisible cursor refreshing every 60 secs
-
-genericDisplayerLolcat.sh #####   Purpose: bash script to display output and pipe into lolcat refreshing every 60 secs
-
-gitRemoteRepoInformation.sh #####   Purpose: bash script to get remote details from repo name
-
-gitgo.sh #####   Purpose: bash script to facilitate github repo creation and committing
-
-goForward.sh #####   Purpose: bash script to cd to new directory and show contents 
-
-headerSummarizer.sh #####   Purpose: bash script to summarize shell scripts from headers
-
-indenterAndDuplicateLineDeleter.sh #####   Purpose: bash script to reindent and delete duplicate lines
-
-info.sh #####   Purpose: bash script to show computer info
-
-iostatShower.sh #####   Purpose: bash  script to show io stats
-
-listAllCommands.sh #####   Purpose: bash script to list all comamnds in PATH
-
-logs.sh #####   Purpose: bash script to  monitor all log files with rainbow effect
-
-menkeTech.sh #####   Purpose: bash script to print out Menke Technologies with figlet
-
-menkeTechLolcat.sh #####   Purpose: bash script to print out Menke Tech with figlet and rainbow color
-
-myWatchNoBlink.sh #####   Purpose: bash script to continuously monitor output of a process
-
-myWatchNoBlinkColorized.sh #####   Purpose: bash script to watch output of an command with color
-
-mywatch.sh #####   Purpose: bash script to watch output of command using clear
-
-oldCounter.sh #####   Purpose: bash script to count all commands in PATH
-
-openAll.sh #####   Purpose: bash script to open all files of given type
-
-picture_finder.sh #####   Purpose: bash script to find all pics 
-
-printHeader.sh #####   Purpose: bash script to print banner with perl
-
-pydfShower.sh #####   Purpose: bash script to show output of pydf
-
-readFIFO.sh #####   Purpose: bash script to read from fifo pipe 
-
-redText.sh #####   Purpose: bash script for filtering text
-
-rpiDownloader.sh #####   Purpose: bash  script to download from RPi to local host
-
-rpiSoftwareUpdater.sh #####   Purpose: bash script to update software on the RPI itself
-
-rsyncr.sh #####   Purpose: bash script to rsync to RPi and upload to Tomcat
-
-runner.sh #####   Purpose: bash script to help exec of script from vim
-
-secureDelete.sh #####   Purpose: bash script to securely delete a file with no hope of recovery
-
-shebangChanger.sh #####   Purpose: bash script to change the shebang line
-
-sortedArrayCounter.sh #####   Purpose: bash script to see sorted commands in PATH 
-
-sshTunnelVnc.sh #####   Purpose: bash script to pipe vnc through ssh tunnel
-
-sshTunnelVnc2.sh #####   Purpose: bash script to pipe vnc through ssh to RPi2 
-
-stresser.sh #####   Purpose: bash script to stress system 
-
-sync.sh #####   Purpose: bash script to sync two directories 
-
-templater.sh #####   Purpose: file templates for bash, perl, python
-
-
-textmessage.sh #####   Purpose: bash  script to facilitate text messaging from command line 
-
-transfer.sh #####   Purpose: bash script to transfer file through scp
-
-upLoadDS.sh #####   Purpose: bash script to upload file to NAS
-
-upLoadPi.sh #####   Purpose: bash  script to to upload to RPi
-
-upLoadPi2.sh #####   Purpose: bash  script to to upload to RPi
-
-updater.sh #####   Purpose: bash  script to update all command line packages locally and on servers 
-
-updaterEmail.sh #####   Purpose: bash script for updating and sending email with results
-
-updaterForLaunchCtl.sh #####   Purpose: bash script to run updater scripts, output to logfile
-
-uploadWebDS.sh #####   Purpose: bash script to upload to web direcctory of NAS
-
-uploadWebPi.sh #####   Purpose: bash script to upload to web dir of RPi
-
-watchServiceFSWatchGit.sh #####   Purpose: bash script to push to Github on file change
-
-watchServiceFSWatchLS-ALH.sh #####   Purpose: bash script to list files on file change
-
-watchServiceFSWatchPiDesktop.sh #####   Purpose: bash script to upload to RPi on file change
-
-watchServiceFSWatchPiWeb.sh #####   Purpose: bash script to upload to RPi web dir on file change
-
-watchServiceFSWatchRustCompile.sh #####   Purpose: bash script to compile rust file on file change
-
-watchtree1.sh #####   Purpose: bash  script to show tree of procs 
-
-watchtree1Color.sh #####   Purpose: bash script to show tree of processes
-
-watchtree2.sh #####   Purpose: bash script to monitor tree of processes
-
-# Mac Only Scripts
-figletRandomFont.sh #####   Purpose: bash script to display random figlet fonts
-
-figletRandomFontOnce.sh #####   Purpose: bash script to display random figlet fonts
-
-getPath.sh #####   Purpose: bash script to add abs path to system clipboard on Mac
-
-istatsShower.sh #####   Purpose: bash script to display temps  
-
-keyboardMaestro.sh #####   Purpose: bash script to aid keyboard maestro actions
-
-menkeTechRandomFont.sh #####   Purpose: bash script to display random figlet fonts
-
-say.sh #####   Purpose: bash script to try out all macOS voices
-
-tor.sh #####   Purpose: bash script to use tor network
-
-tutorialConfigUpdater.sh #####   Purpose:  script to update multiple Github repos
-
+ [archetypeShower.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/archetypeShower.sh                       ) Purpose: bash script to show screenfetch
+                                                                                                                                                                  
+ [backupBashConfig.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/backupBashConfig.sh                               ) Purpose: bash script to backup dotfiles 
+                                                                                                                                                                  
+ [batchRename.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/batchRename.sh                                    ) Purpose: bash script to rename multiple files
+                                                                                                                                                                 
+ [blueText.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/blueText.sh                                       ) Purpose: bash script for making text blue    
+                                                                                                                                                                  
+ [blueUpperText.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/blueUpperText.sh                                  ) Purpose: bash script to make text white on blue background and some underscores
+                                                                                                                                                                  
+ [boldText.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/boldText.sh                                       ) Purpose: bash script to bold text                                              
+                                                                                                                                                                 
+ [clearTrash.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/clearTrash.sh                                     ) Purpose: bash script to empty trash                                            
+                                                                                                                                                                  
+ [colorLogger.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/colorLogger.sh                                    ) Purpose: bash script to monitor log files in color                             
+                                                                                                                                                                  
+ [connectionShower.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/connectionShower.sh                      ) Purpose: bash script to continuously monitor open files                        
+                                                                                    
+ [coolFormatter.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/coolFormatter.sh                         ) Purpose: bash script to add funky formatting                                   
+                                                                                                                                                         
+ [createScriptButDontOpenSublime.sh      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/createScriptButDontOpenSublime.sh        ) Purpose: bash script to add shebang line to new script file                    
+                                                                                                                                                         
+ [createTextFile.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/createTextFile.sh                        ) Purpose: bash script to create new script and edit it with SublimeText         
+                                                                                    
+ [directoryContentsSize.sh               ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/directoryContentsSize.sh                 ) Purpose: bash script to list files and folders in pwd and optionally sort by size       
+                                                                                                                                                         
+ [dsDownloader.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/dsDownloader.sh                          ) Purpose: bash  script to download from RPi to local host                                
+                                                                                                                                                         
+ [duplicateLineDeleter.sh                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/duplicateLineDeleter.sh                  ) Purpose: bash script to remove lines with no contents (squeeze)                         
+                                                                                    
+ [eyes.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/eyes.sh                                  ) Purpose: bash script to show cowsay eyes                                                
+                                                                                                                                                         
+ [genericDisplayer.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/genericDisplayer.sh                      ) Purpose: bash script to display output with invisible cursor refreshing every 60 secs   
+                                                                                                                                                         
+ [genericDisplayerLolcat.sh              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/genericDisplayerLolcat.sh                ) Purpose: bash script to display output and pipe into lolcat refreshing every 60 secs    
+                                                                                    
+ [gitRemoteRepoInformation.sh            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/gitRemoteRepoInformation.sh              ) Purpose: bash script to get remote details from repo name                               
+                                                                                                                                                         
+ [gitgo.sh                               ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/gitgo.sh                                 ) Purpose: bash script to facilitate github repo creation and committing                  
+                                                                                                                                                         
+ [goForward.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/goForward.sh                             ) Purpose: bash script to cd to new directory and show contents                           
+                                                                                    
+ [headerSummarizer.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/headerSummarizer.sh                      ) Purpose: bash script to summarize shell scripts from headers                            
+                                                                                                                                                         
+ [indenterAndDuplicateLineDeleter.sh     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/indenterAndDuplicateLineDeleter.sh       ) Purpose: bash script to reindent and delete duplicate lines                             
+                                                                                                                                                         
+ [info.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/info.sh                                  ) Purpose: bash script to show computer info                                              
+                                          
+ [iostatShower.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/iostatShower.sh                          ) Purpose: bash  script to show io stats                                                  
+                                                                                                                                                         
+ [listAllCommands.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/listAllCommands.sh                       ) Purpose: bash script to list all comamnds in PATH                                       
+                                                                                                                                                         
+ [logs.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/logs.sh                                  ) Purpose: bash script to  monitor all log files with rainbow effect                      
+                                                                                    
+ [menkeTech.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTech.sh                             ) Purpose: bash script to print out Menke Technologies with figlet                        
+                                                                                                                                                         
+ [menkeTechLolcat.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTechLolcat.sh                       ) Purpose: bash script to print out Menke Tech with figlet and rainbow color              
+                                                                                                                                                         
+ [myWatchNoBlink.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/myWatchNoBlink.sh                        ) Purpose: bash script to continuously monitor output of a process
+                                                                                    
+ [myWatchNoBlinkColorized.sh             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/myWatchNoBlinkColorized.sh               ) Purpose: bash script to watch output of an command with color   
+                                                                                                                                                         
+ [mywatch.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/mywatch.sh                               ) Purpose: bash script to watch output of command using clear     
+                                                                                                                                                         
+ [oldCounter.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/oldCounter.sh                            ) Purpose: bash script to count all commands in PATH       
+                                                                                    
+ [openAll.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/openAll.sh                               ) Purpose: bash script to open all files of given type     
+                                                                                                                                                         
+ [picture_finder.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/picture_finder.sh                        ) Purpose: bash script to find all pics                    
+                                                                                                                                                         
+ [printHeader.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/printHeader.sh                           ) Purpose: bash script to print banner with perl           
+                                                                                    
+ [pydfShower.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/pydfShower.sh                            ) Purpose: bash script to show output of pydf              
+                                                                                                                                                         
+ [readFIFO.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/readFIFO.sh                              ) Purpose: bash script to read from fifo pipe              
+                                                                                                                                                         
+ [redText.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/redText.sh                               ) Purpose: bash script for filtering text                  
+                                                                                    
+ [rpiDownloader.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rpiDownloader.sh                         ) Purpose: bash  script to download from RPi to local host 
+                                                                                                                                                         
+ [rpiSoftwareUpdater.sh                  ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rpiSoftwareUpdater.sh                    ) Purpose: bash script to update software on the RPI itself
+                                                                                                                                                         
+ [rsyncr.sh                              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rsyncr.sh                                ) Purpose: bash script to rsync to RPi and upload to Tomcat 
+                                                                                    
+ [runner.sh                              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/runner.sh                                ) Purpose: bash script to help exec of script from vim      
+                                                                                                                                                         
+ [secureDelete.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/secureDelete.sh                          ) Purpose: bash script to securely delete a file with no hope of recovery                 
+                                                                                                                                                         
+ [shebangChanger.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/shebangChanger.sh                        ) Purpose: bash script to change the shebang line     
+                                                                                    
+ [sortedArrayCounter.sh                  ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sortedArrayCounter.sh                    ) Purpose: bash script to see sorted commands in PATH 
+                                                                                                                                                         
+ [sshTunnelVnc.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sshTunnelVnc.sh                          ) Purpose: bash script to pipe vnc through ssh tunnel 
+                                                                                                                                                         
+ [sshTunnelVnc2.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sshTunnelVnc2.sh                         ) Purpose: bash script to pipe vnc through ssh to RPi2
+                                          
+ [stresser.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/stresser.sh                              ) Purpose: bash script to stress system               
+                                                                                                                                                         
+ [sync.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sync.sh                                  ) Purpose: bash script to sync two directories        
+                                                                                                                                                         
+ [templater.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/templater.sh                             ) Purpose: file templates for bash, perl, python      
+                                                                                    
+ [textmessage.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/textmessage.sh                           ) Purpose: bash  script to facilitate text messaging from command line                    
+                                                                                                                                                         
+ [transfer.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/transfer.sh                              ) Purpose: bash script to transfer file through scp 
+                                                                                                                                                         
+ [upLoadDS.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadDS.sh                              ) Purpose: bash script to upload file to NAS        
+                                                                                    
+ [upLoadPi.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadPi.sh                              ) Purpose: bash  script to to upload to RPi         
+                                                                                                                                                         
+ [upLoadPi2.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadPi2.sh                             ) Purpose: bash  script to to upload to RPi         
+                                                                                                                                                         
+ [updater.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updater.sh                               ) Purpose: bash  script to update all command line packages locally and on servers        
+                                                                                    
+ [updaterEmail.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updaterEmail.sh                          ) Purpose: bash script for updating and sending email with results                        
+                                                                                                                                                         
+ [updaterForLaunchCtl.sh                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updaterForLaunchCtl.sh                   ) Purpose: bash script to run updater scripts, output to logfile                          
+                                                                                                                                                         
+ [uploadWebDS.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/uploadWebDS.sh                           ) Purpose: bash script to upload to web direcctory of NAS                                 
+                                                                                    
+ [uploadWebPi.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/uploadWebPi.sh                           ) Purpose: bash script to upload to web dir of RPi      
+                                                                                                                                                         
+ [watchServiceFSWatchGit.sh              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchGit.sh                ) Purpose: bash script to push to Github on file change 
+                                                                                                                                                         
+ [watchServiceFSWatchLS-ALH.sh           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchLS-ALH.sh             ) Purpose: bash script to list files on file change     
+                                                                                    
+ [watchServiceFSWatchPiDesktop.sh        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchPiDesktop.sh          ) Purpose: bash script to upload to RPi on file change  
+                                                                                                                                                         
+ [watchServiceFSWatchPiWeb.sh            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchPiWeb.sh              ) Purpose: bash script to upload to RPi web dir on file change 
+                                                                                                                                                         
+ [watchServiceFSWatchRustCompile.sh      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchRustCompile.sh        ) Purpose: bash script to compile rust file on file change     
+                                                                                    
+ [watchtree1.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree1.sh                            ) Purpose: bash  script to show tree of procs                  
+                                                                                                                                                         
+ [watchtree1Color.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree1Color.sh                       ) Purpose: bash script to show tree of processes               
+                                                                                                                                                        
+ [watchtree2.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree2.sh                            ) Purpose: bash script to monitor tree of processes            
+                                         
+# Mac Only Scripts                       
+ [figletRandomFont.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/figletRandomFont.sh                      ) Purpose: bash script to display random figlet fonts          
+                                                                                                                                                         
+ [figletRandomFontOnce.sh                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/figletRandomFontOnce.sh                  ) Purpose: bash script to display random figlet fonts          
+                                                                                                                                                         
+ [getPath.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/getPath.sh                               ) Purpose: bash script to add abs path to system clipboard on Mac 
+                                                                                    
+ [istatsShower.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/istatsShower.sh                          ) Purpose: bash script to display temps                           
+                                                                                                                                                         
+ [keyboardMaestro.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/keyboardMaestro.sh                       ) Purpose: bash script to aid keyboard maestro actions            
+                                                                                                                                                         
+ [menkeTechRandomFont.sh                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTechRandomFont.sh                   ) Purpose: bash script to display random figlet fonts             
+                                                                                    
+ [say.sh                                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/say.sh                                   ) Purpose: bash script to try out all macOS voices                
+                                                                                                                                                         
+ [tor.sh                                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/tor.sh                                   ) Purpose: bash script to use tor network                         
+                                                                                                                                                         
+ [tutorialConfigUpdater.sh               ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/tutorialConfigUpdater.sh                 ) Purpose:  script to update multiple Github repos                

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,157 +1,158 @@
 # Mac and Linux Scripts
- [archetypeShower.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/archetypeShower.sh                       ) Purpose: bash script to show screenfetch
-                                                                                                                                                                  
- [backupBashConfig.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/backupBashConfig.sh                               ) Purpose: bash script to backup dotfiles 
-                                                                                                                                                                  
- [batchRename.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/batchRename.sh                                    ) Purpose: bash script to rename multiple files
-                                                                                                                                                                 
- [blueText.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/blueText.sh                                       ) Purpose: bash script for making text blue    
-                                                                                                                                                                  
- [blueUpperText.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/blueUpperText.sh                                  ) Purpose: bash script to make text white on blue background and some underscores
-                                                                                                                                                                  
- [boldText.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/boldText.sh                                       ) Purpose: bash script to bold text                                              
-                                                                                                                                                                 
- [clearTrash.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/clearTrash.sh                                     ) Purpose: bash script to empty trash                                            
-                                                                                                                                                                  
- [colorLogger.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/colorLogger.sh                                    ) Purpose: bash script to monitor log files in color                             
-                                                                                                                                                                  
- [connectionShower.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/connectionShower.sh                      ) Purpose: bash script to continuously monitor open files                        
-                                                                                    
- [coolFormatter.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/coolFormatter.sh                         ) Purpose: bash script to add funky formatting                                   
-                                                                                                                                                         
- [createScriptButDontOpenSublime.sh      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/createScriptButDontOpenSublime.sh        ) Purpose: bash script to add shebang line to new script file                    
-                                                                                                                                                         
- [createTextFile.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/createTextFile.sh                        ) Purpose: bash script to create new script and edit it with SublimeText         
-                                                                                    
- [directoryContentsSize.sh               ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/directoryContentsSize.sh                 ) Purpose: bash script to list files and folders in pwd and optionally sort by size       
-                                                                                                                                                         
- [dsDownloader.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/dsDownloader.sh                          ) Purpose: bash  script to download from RPi to local host                                
-                                                                                                                                                         
- [duplicateLineDeleter.sh                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/duplicateLineDeleter.sh                  ) Purpose: bash script to remove lines with no contents (squeeze)                         
-                                                                                    
- [eyes.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/eyes.sh                                  ) Purpose: bash script to show cowsay eyes                                                
-                                                                                                                                                         
- [genericDisplayer.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/genericDisplayer.sh                      ) Purpose: bash script to display output with invisible cursor refreshing every 60 secs   
-                                                                                                                                                         
- [genericDisplayerLolcat.sh              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/genericDisplayerLolcat.sh                ) Purpose: bash script to display output and pipe into lolcat refreshing every 60 secs    
-                                                                                    
- [gitRemoteRepoInformation.sh            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/gitRemoteRepoInformation.sh              ) Purpose: bash script to get remote details from repo name                               
-                                                                                                                                                         
- [gitgo.sh                               ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/gitgo.sh                                 ) Purpose: bash script to facilitate github repo creation and committing                  
-                                                                                                                                                         
- [goForward.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/goForward.sh                             ) Purpose: bash script to cd to new directory and show contents                           
-                                                                                    
- [headerSummarizer.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/headerSummarizer.sh                      ) Purpose: bash script to summarize shell scripts from headers                            
-                                                                                                                                                         
- [indenterAndDuplicateLineDeleter.sh     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/indenterAndDuplicateLineDeleter.sh       ) Purpose: bash script to reindent and delete duplicate lines                             
-                                                                                                                                                         
- [info.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/info.sh                                  ) Purpose: bash script to show computer info                                              
-                                          
- [iostatShower.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/iostatShower.sh                          ) Purpose: bash  script to show io stats                                                  
-                                                                                                                                                         
- [listAllCommands.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/listAllCommands.sh                       ) Purpose: bash script to list all comamnds in PATH                                       
-                                                                                                                                                         
- [logs.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/logs.sh                                  ) Purpose: bash script to  monitor all log files with rainbow effect                      
-                                                                                    
- [menkeTech.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTech.sh                             ) Purpose: bash script to print out Menke Technologies with figlet                        
-                                                                                                                                                         
- [menkeTechLolcat.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTechLolcat.sh                       ) Purpose: bash script to print out Menke Tech with figlet and rainbow color              
-                                                                                                                                                         
- [myWatchNoBlink.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/myWatchNoBlink.sh                        ) Purpose: bash script to continuously monitor output of a process
-                                                                                    
- [myWatchNoBlinkColorized.sh             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/myWatchNoBlinkColorized.sh               ) Purpose: bash script to watch output of an command with color   
-                                                                                                                                                         
- [mywatch.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/mywatch.sh                               ) Purpose: bash script to watch output of command using clear     
-                                                                                                                                                         
- [oldCounter.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/oldCounter.sh                            ) Purpose: bash script to count all commands in PATH       
-                                                                                    
- [openAll.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/openAll.sh                               ) Purpose: bash script to open all files of given type     
-                                                                                                                                                         
- [picture_finder.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/picture_finder.sh                        ) Purpose: bash script to find all pics                    
-                                                                                                                                                         
- [printHeader.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/printHeader.sh                           ) Purpose: bash script to print banner with perl           
-                                                                                    
- [pydfShower.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/pydfShower.sh                            ) Purpose: bash script to show output of pydf              
-                                                                                                                                                         
- [readFIFO.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/readFIFO.sh                              ) Purpose: bash script to read from fifo pipe              
-                                                                                                                                                         
- [redText.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/redText.sh                               ) Purpose: bash script for filtering text                  
-                                                                                    
- [rpiDownloader.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rpiDownloader.sh                         ) Purpose: bash  script to download from RPi to local host 
-                                                                                                                                                         
- [rpiSoftwareUpdater.sh                  ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rpiSoftwareUpdater.sh                    ) Purpose: bash script to update software on the RPI itself
-                                                                                                                                                         
- [rsyncr.sh                              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rsyncr.sh                                ) Purpose: bash script to rsync to RPi and upload to Tomcat 
-                                                                                    
- [runner.sh                              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/runner.sh                                ) Purpose: bash script to help exec of script from vim      
-                                                                                                                                                         
- [secureDelete.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/secureDelete.sh                          ) Purpose: bash script to securely delete a file with no hope of recovery                 
-                                                                                                                                                         
- [shebangChanger.sh                      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/shebangChanger.sh                        ) Purpose: bash script to change the shebang line     
-                                                                                    
- [sortedArrayCounter.sh                  ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sortedArrayCounter.sh                    ) Purpose: bash script to see sorted commands in PATH 
-                                                                                                                                                         
- [sshTunnelVnc.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sshTunnelVnc.sh                          ) Purpose: bash script to pipe vnc through ssh tunnel 
-                                                                                                                                                         
- [sshTunnelVnc2.sh                       ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sshTunnelVnc2.sh                         ) Purpose: bash script to pipe vnc through ssh to RPi2
-                                          
- [stresser.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/stresser.sh                              ) Purpose: bash script to stress system               
-                                                                                                                                                         
- [sync.sh                                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sync.sh                                  ) Purpose: bash script to sync two directories        
-                                                                                                                                                         
- [templater.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/templater.sh                             ) Purpose: file templates for bash, perl, python      
-                                                                                    
- [textmessage.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/textmessage.sh                           ) Purpose: bash  script to facilitate text messaging from command line                    
-                                                                                                                                                         
- [transfer.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/transfer.sh                              ) Purpose: bash script to transfer file through scp 
-                                                                                                                                                         
- [upLoadDS.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadDS.sh                              ) Purpose: bash script to upload file to NAS        
-                                                                                    
- [upLoadPi.sh                            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadPi.sh                              ) Purpose: bash  script to to upload to RPi         
-                                                                                                                                                         
- [upLoadPi2.sh                           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadPi2.sh                             ) Purpose: bash  script to to upload to RPi         
-                                                                                                                                                         
- [updater.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updater.sh                               ) Purpose: bash  script to update all command line packages locally and on servers        
-                                                                                    
- [updaterEmail.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updaterEmail.sh                          ) Purpose: bash script for updating and sending email with results                        
-                                                                                                                                                         
- [updaterForLaunchCtl.sh                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updaterForLaunchCtl.sh                   ) Purpose: bash script to run updater scripts, output to logfile                          
-                                                                                                                                                         
- [uploadWebDS.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/uploadWebDS.sh                           ) Purpose: bash script to upload to web direcctory of NAS                                 
-                                                                                    
- [uploadWebPi.sh                         ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/uploadWebPi.sh                           ) Purpose: bash script to upload to web dir of RPi      
-                                                                                                                                                         
- [watchServiceFSWatchGit.sh              ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchGit.sh                ) Purpose: bash script to push to Github on file change 
-                                                                                                                                                         
- [watchServiceFSWatchLS-ALH.sh           ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchLS-ALH.sh             ) Purpose: bash script to list files on file change     
-                                                                                    
- [watchServiceFSWatchPiDesktop.sh        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchPiDesktop.sh          ) Purpose: bash script to upload to RPi on file change  
-                                                                                                                                                         
- [watchServiceFSWatchPiWeb.sh            ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchPiWeb.sh              ) Purpose: bash script to upload to RPi web dir on file change 
-                                                                                                                                                         
- [watchServiceFSWatchRustCompile.sh      ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchRustCompile.sh        ) Purpose: bash script to compile rust file on file change     
-                                                                                    
- [watchtree1.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree1.sh                            ) Purpose: bash  script to show tree of procs                  
-                                                                                                                                                         
- [watchtree1Color.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree1Color.sh                       ) Purpose: bash script to show tree of processes               
-                                                                                                                                                        
- [watchtree2.sh                          ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree2.sh                            ) Purpose: bash script to monitor tree of processes            
-                                         
+ [archetypeShower.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/archetypeShower.sh) ------ Purpose: bash script to show screenfetch
+
+ [backupBashConfig.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/backupBashConfig.sh) ----- Purpose: bash script to backup dotfiles
+
+ [batchRename.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/batchRename.sh) ----------  Purpose: bash script to rename multiple files
+
+ [blueText.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/blueText.sh) ---------------  Purpose: bash script for making text blue    
+
+ [blueUpperText.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/blueUpperText.sh) ---------  Purpose: bash script to make text white on blue background and some underscores
+
+ [boldText.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/boldText.sh) ---------------  Purpose: bash script to bold text                                              
+
+ [clearTrash.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/clearTrash.sh) -------------  Purpose: bash script to empty trash                                            
+
+ [colorLogger.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/colorLogger.sh) ------------  Purpose: bash script to monitor log files in color                             
+
+ [connectionShower.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/connectionShower.sh) ----- Purpose: bash script to continuously monitor open files                        
+
+ [coolFormatter.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/coolFormatter.sh) ----------  Purpose: bash script to add funky formatting                                   
+
+ [createScriptButDontOpenSublime.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/createScriptButDontOpenSublime.sh        ) ----------  Purpose: bash script to add shebang line to new script file                    
+
+ [createTextFile.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/createTextFile.sh) ---------  Purpose: bash script to create new script and edit it with SublimeText         
+
+ [directoryContentsSize.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/directoryContentsSize.sh) -  Purpose: bash script to list files and folders in pwd and optionally sort by size       
+
+ [dsDownloader.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/dsDownloader.sh) ---------  Purpose: bash  script to download from RPi to local host                                
+
+ [duplicateLineDeleter.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/duplicateLineDeleter.sh) --  Purpose: bash script to remove lines with no contents (squeeze)                         
+
+ [eyes.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/eyes.sh) ------------------  Purpose: bash script to show cowsay eyes                                                
+
+ [genericDisplayer.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/genericDisplayer.sh) ------  Purpose: bash script to display output with invisible cursor refreshing every 60 secs   
+
+ [genericDisplayerLolcat.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/genericDisplayerLolcat.sh) -  Purpose: bash script to display output and pipe into lolcat refreshing every 60 secs    
+
+ [gitRemoteRepoInformation.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/gitRemoteRepoInformation.sh) ----------  Purpose: bash script to get remote details from repo name                               
+
+ [gitgo.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/gitgo.sh) ------------------  Purpose: bash script to facilitate github repo creation and committing                  
+
+ [goForward.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/goForward.sh) ------------  Purpose: bash script to cd to new directory and show contents                           
+
+ [headerSummarizer.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/headerSummarizer.sh) ----  Purpose: bash script to summarize shell scripts from headers                            
+
+ [indenterAndDuplicateLineDeleter.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/indenterAndDuplicateLineDeleter.sh) ----------  Purpose: bash script to reindent and delete duplicate lines                             
+
+ [info.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/info.sh) -------------------  Purpose: bash script to show computer info                                              
+
+ [iostatShower.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/iostatShower.sh) ----------  Purpose: bash  script to show io stats                                                  
+
+ [listAllCommands.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/listAllCommands.sh) ------  Purpose: bash script to list all comamnds in PATH                                       
+
+ [logs.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/logs.sh) ------------------  Purpose: bash script to  monitor all log files with rainbow effect                      
+
+ [menkeTech.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTech.sh) -----------  Purpose: bash script to print out Menke Technologies with figlet                        
+
+ [menkeTechLolcat.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTechLolcat.sh)  ------ Purpose: bash script to print out Menke Tech with figlet and rainbow color              
+
+ [myWatchNoBlink.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/myWatchNoBlink.sh)  ------ Purpose: bash script to continuously monitor output of a process
+
+
+ [myWatchNoBlinkColorized.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/myWatchNoBlinkColorized.sh) ----------  Purpose: bash script to watch output of an command with color   
+
+ [mywatch.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/mywatch.sh) --------------  Purpose: bash script to watch output of command using clear     
+
+ [oldCounter.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/oldCounter.sh) ------------  Purpose: bash script to count all commands in PATH       
+
+ [openAll.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/openAll.sh) ---------------  Purpose: bash script to open all files of given type     
+
+ [picture_finder.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/picture_finder.sh) ---------  Purpose: bash script to find all pics                    
+
+ [printHeader.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/printHeader.sh) -----------  Purpose: bash script to print banner with perl           
+
+ [pydfShower.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/pydfShower.sh) ----------  Purpose: bash script to show output of pydf              
+
+ [readFIFO.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/readFIFO.sh) -------------  Purpose: bash script to read from fifo pipe              
+
+ [redText.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/redText.sh) --------------  Purpose: bash script for filtering text                  
+
+ [rpiDownloader.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rpiDownloader.sh) -------  Purpose: bash  script to download from RPi to local host
+
+ [rpiSoftwareUpdater.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rpiSoftwareUpdater.sh) --  Purpose: bash script to update software on the RPI itself
+
+ [rsyncr.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/rsyncr.sh) ---------------  Purpose: bash script to rsync to RPi and upload to Tomcat
+
+ [runner.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/runner.sh) ---------------  Purpose: bash script to help exec of script from vim      
+
+ [secureDelete.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/secureDelete.sh) ---------  Purpose: bash script to securely delete a file with no hope of recovery                 
+
+ [shebangChanger.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/shebangChanger.sh) -----  Purpose: bash script to change the shebang line     
+
+ [sortedArrayCounter.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sortedArrayCounter.sh) --  Purpose: bash script to see sorted commands in PATH
+
+ [sshTunnelVnc.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sshTunnelVnc.sh) -------  Purpose: bash script to pipe vnc through ssh tunnel
+
+ [sshTunnelVnc2.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sshTunnelVnc2.sh) ------  Purpose: bash script to pipe vnc through ssh to RPi2
+
+ [stresser.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/stresser.sh) -------------  Purpose: bash script to stress system               
+
+ [sync.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/sync.sh) -----------------  Purpose: bash script to sync two directories        
+
+ [templater.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/templater.sh) ------------  Purpose: file templates for bash, perl, python      
+
+ [textmessage.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/textmessage.sh) --------  Purpose: bash  script to facilitate text messaging from command line                    
+
+ [transfer.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/transfer.sh) -------------  Purpose: bash script to transfer file through scp
+
+ [upLoadDS.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadDS.sh) -----------  Purpose: bash script to upload file to NAS        
+
+ [upLoadPi.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadPi.sh) ------------  Purpose: bash  script to to upload to RPi         
+
+ [upLoadPi2.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/upLoadPi2.sh) ----------  Purpose: bash  script to to upload to RPi         
+
+ [updater.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updater.sh) -------------  Purpose: bash  script to update all command line packages locally and on servers        
+
+ [updaterEmail.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updaterEmail.sh) --------  Purpose: bash script for updating and sending email with results                        
+
+ [updaterForLaunchCtl.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/updaterForLaunchCtl.sh) -  Purpose: bash script to run updater scripts, output to logfile   
+
+ [uploadWebDS.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/uploadWebDS.sh) -------  Purpose: bash script to upload to web direcctory of NAS                                 
+
+ [uploadWebPi.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/uploadWebPi.sh) --------  Purpose: bash script to upload to web dir of RPi      
+
+ [watchServiceFSWatchGit.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchGit.sh) --------  Purpose: bash script to push to Github on file change
+
+ [watchServiceFSWatchLS-ALH.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchLS-ALH.sh) ---  Purpose: bash script to list files on file change     
+
+ [watchServiceFSWatchPiDesktop.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchPiDesktop.sh) -  Purpose: bash script to upload to RPi on file change  
+
+ [watchServiceFSWatchPiWeb.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchPiWeb.sh) -------  Purpose: bash script to upload to RPi web dir on file change
+
+ [watchServiceFSWatchRustCompile.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchServiceFSWatchRustCompile.sh) - Purpose: bash script to compile rust file on file change     
+
+ [watchtree1.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree1.sh) --------  Purpose: bash  script to show tree of procs                  
+
+ [watchtree1Color.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree1Color.sh) ---  Purpose: bash script to show tree of processes               
+
+ [watchtree2.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/watchtree2.sh) -------- Purpose: bash script to monitor tree of processes            
+
 # Mac Only Scripts                       
- [figletRandomFont.sh                    ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/figletRandomFont.sh                      ) Purpose: bash script to display random figlet fonts          
-                                                                                                                                                         
- [figletRandomFontOnce.sh                ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/figletRandomFontOnce.sh                  ) Purpose: bash script to display random figlet fonts          
-                                                                                                                                                         
- [getPath.sh                             ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/getPath.sh                               ) Purpose: bash script to add abs path to system clipboard on Mac 
-                                                                                    
- [istatsShower.sh                        ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/istatsShower.sh                          ) Purpose: bash script to display temps                           
-                                                                                                                                                         
- [keyboardMaestro.sh                     ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/keyboardMaestro.sh                       ) Purpose: bash script to aid keyboard maestro actions            
-                                                                                                                                                         
- [menkeTechRandomFont.sh                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTechRandomFont.sh                   ) Purpose: bash script to display random figlet fonts             
-                                                                                    
- [say.sh                                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/say.sh                                   ) Purpose: bash script to try out all macOS voices                
-                                                                                                                                                         
- [tor.sh                                 ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/tor.sh                                   ) Purpose: bash script to use tor network                         
-                                                                                                                                                         
- [tutorialConfigUpdater.sh               ](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/tutorialConfigUpdater.sh                 ) Purpose:  script to update multiple Github repos                
+ [figletRandomFont.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/figletRandomFont.sh) ----------  Purpose: bash script to display random figlet fonts          
+
+ [figletRandomFontOnce.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/figletRandomFontOnce.sh) ----  Purpose: bash script to display random figlet fonts          
+
+ [getPath.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/getPath.sh) -------------------  Purpose: bash script to add abs path to system clipboard on Mac
+
+ [istatsShower.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/istatsShower.sh) --------------  Purpose: bash script to display temps                           
+
+ [keyboardMaestro.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/keyboardMaestro.sh)  ---------- Purpose: bash script to aid keyboard maestro actions            
+
+ [menkeTechRandomFont.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/menkeTechRandomFont.sh) ---  Purpose: bash script to display random figlet fonts             
+
+ [say.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/say.sh) -------------------------  Purpose: bash script to try out all macOS voices                
+
+ [tor.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/tor.sh) -------------------------  Purpose: bash script to use tor network                         
+
+ [tutorialConfigUpdater.sh](https://github.com/MenkeTechnologies/TutorialFiles/tree/master/shell/tutorialConfigUpdater.sh) ------  Purpose:  script to update multiple Github repos                


### PR DESCRIPTION
With the first commit "add links":
Left spacing in readme so that new elements such as ```<b>``` could be added with visual block in vim.
Not sure how to space purpose out evenly, such as with tabs in markdown.